### PR TITLE
Send Initialize command only once

### DIFF
--- a/synscan/motors.py
+++ b/synscan/motors.py
@@ -127,7 +127,7 @@ class motors(comm):
         return T1preset
 
 
-    def get_values(self,parameterDict):
+    def get_values(self,parameterDict,initDone=True):
         '''
         Send all cmd in the parameterDict for both axis and return
         a dictionary with the values.
@@ -145,7 +145,8 @@ class motors(comm):
                     logging.warning(error)
                     raise(NameError('getValuesError'))
             #Send init done
-            self._send_cmd('F',axis)  # Initialize
+            if initDone:
+                self._send_cmd('F',axis)  # Initialize
         return params
 
     def get_parameters(self):
@@ -170,7 +171,7 @@ class motors(comm):
                         'HighSpeedRatio':'g',       # Inquire High Speed Ratio
                         }
         try:
-            params=self.get_values(parameterDict)
+            params=self.get_values(parameterDict, initDone=True)
         except NameError as error:
             logging.warning(error)
             raise(NameError('getParametersError'))
@@ -506,7 +507,7 @@ class motors(comm):
                         }
         retrySec = 2
         try:
-          params=self.get_values(parameterDict)
+          params=self.get_values(parameterDict, initDone=False)
 
           for parameter in ['GotoTarget','Position']:
               for axis in range(1,3):


### PR DESCRIPTION
On my SkyWatcher Virtuoso (version 2.16 firmware), an axis stops when it receives the Initialize ("F") command.

Currently `get_values` always sends `F` to both axes, both on startup (`__init__` > `_init` > `get_parameters` > `get_values`) and while updating an axis' position (via `update_current_values` > `get_values`). This had the effect that f.i. `track(10, 10)` would only get movement on one axis simultaneously, since in the process of setting up the speed for axis 2, an Initialize is sent to axis 1 which stopped it.

This patch fixes this by only sending the Initialize on startup (via `get_parameters`), and not when updating positions (`update_current_values`).